### PR TITLE
Fix for options opening, fix for client hanging after loading screens

### DIFF
--- a/FarmBuddy.lua
+++ b/FarmBuddy.lua
@@ -64,8 +64,8 @@ function FarmBuddy:OnInitialize()
   self.db = LibStub('AceDB-3.0'):New(FARM_BUDDY_ID .. 'DB', DEFAULTS);
 
   -- Register events
-  self:RegisterEvent('BAG_UPDATE', 'BagUpdate');
-  self:RegisterEvent('GET_ITEM_INFO_RECEIVED', 'ItemInfoRecived');
+  self:RegisterEvent('BAG_UPDATE_DELAYED', 'BagUpdate');
+  self:RegisterEvent('GET_ITEM_INFO_RECEIVED', 'ItemInfoReceived');
   self:RegisterEvent('PLAYER_REGEN_DISABLED', 'PlayerRegenDisabled');
   self:RegisterEvent('PLAYER_REGEN_ENABLED', 'PlayerRegenEnabled');
   self:RegisterEvent('PET_BATTLE_OPENING_START', 'PlayerRegenDisabled');
@@ -102,7 +102,7 @@ end
 function FarmBuddy:OnEnable()
   self:SecureHook('HandleModifiedItemClick', 'ModifiedClick');
   self:ScheduleRepeatingTimer('NotificationTask', 1);
-  self:ScheduleRepeatingTimer('ItemInfoRecived', 5);
+  self:ScheduleRepeatingTimer('ItemInfoReceived', 5);
 end
 
 -- **************************************************************************

--- a/FarmBuddy.toc
+++ b/FarmBuddy.toc
@@ -1,12 +1,12 @@
-## Interface: 110205, 11507, 50500, 50501
+## Interface: 120007,50504,11508
 ## Title: Farm Buddy
 ## IconTexture: Interface\Icons\INV_Misc_Coin_01
 ## Notes: Adds the functionality to track farmed items in a movable window.|n|cffbbbbbbBy Keldor|r|n|nSupport:|n|cff82c5ff- patreon.com/eso_database_com|r|n|n
 ## Author: Keldor (https://www.devil-coding.de)
 ## SavedVariables: FarmBuddyStandaloneDB
-## Version: 1.1.5
-## Category-enUS: Farming
-## Category-deDE: Farmen
+## Version: 1.1.6
+## Category: Inventory
+## Category-deDE: Inventar
 
 embeds.xml
 

--- a/FarmBuddyItem.lua
+++ b/FarmBuddyItem.lua
@@ -60,10 +60,10 @@ function FarmBuddy:AddItemToQueue(uniqueID, item)
 end
 
 -- **************************************************************************
--- NAME : FarmBuddy:ItemInfoRecived()
+-- NAME : FarmBuddy:ItemInfoReceived()
 -- DESC : Called when the item info has recived.
 -- **************************************************************************
-function FarmBuddy:ItemInfoRecived()
+function FarmBuddy:ItemInfoReceived()
 
   for k, v in pairs(ITEM_QUEUE) do
     local itemInfo = self:GetItemInfo(v.itemValue);

--- a/FarmBuddySettings.lua
+++ b/FarmBuddySettings.lua
@@ -19,7 +19,7 @@ local RANDOM_CHARS = {}
 -- **************************************************************************
 function FarmBuddy:InitSettings()
   LibStub('AceConfig-3.0'):RegisterOptionsTable(FARM_BUDDY_ADDON_NAME, FarmBuddy:GetConfigOptions());
-  LibStub('AceConfigDialog-3.0'):AddToBlizOptions(FARM_BUDDY_ADDON_NAME);
+  self.optionsFrame, self.optionsID = LibStub('AceConfigDialog-3.0'):AddToBlizOptions(FARM_BUDDY_ADDON_NAME);
   self:GenerateChars();
   self:LoadExistingConfigItems();
   self:RegisterDialogs();
@@ -1462,7 +1462,7 @@ end
 -- **************************************************************************
 function FarmBuddy:OpenSettings(tab)
 
-  Settings.OpenToCategory(FARM_BUDDY_ADDON_NAME);
+  Settings.OpenToCategory(self.optionsID);
 
   if (tab ~= nil) then
     LibStub('AceConfigDialog-3.0'):SelectGroup(FARM_BUDDY_ADDON_NAME, tab)

--- a/Notification/Notification.lua
+++ b/Notification/Notification.lua
@@ -123,7 +123,7 @@ function FarmBuddyNotification_OnMouseDown(self, button)
 
   if button == 'RightButton' and not self.isMoving then
     self:Hide();
-    Settings.OpenToCategory(FARM_BUDDY_ADDON_NAME);
+    Settings.OpenToCategory(FarmBuddy.optionsID);
   end
 end
 


### PR DESCRIPTION
- Fix medium/large item lists hanging the client after loading screen
- Fix error opening blizzard options from tracker/cmd/minimap icon 
- Rename mispelled API recived > received
- metadata updates

Untested on mainline.